### PR TITLE
fix du LaTeX ne fonctionnant pas sur PC

### DIFF
--- a/sujet.php
+++ b/sujet.php
@@ -243,4 +243,4 @@ if (isset($_GET['id'])) {
 
 
 include("includes/copyright.php"); ?>
-<script type="text/javascript" src="http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>
+<script type="text/javascript" src="https://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML"></script>


### PR DESCRIPTION
Remplacement du http par https pour éviter une erreur de chargement du script et permettre l'affichage du LaTeX sur PC (une autre solution serait d'avoir le script sur le serveur lui-même ce qui éviterai ce genre de bugs à l'avenir) :

`Mixed Content: The page at 'https://theverylittlewar.com/sujet.php?id=951' was loaded over HTTPS, but requested an insecure script 'http://cdn.mathjax.org/mathjax/latest/MathJax.js?config=TeX-AMS-MML_HTMLorMML'. This request has been blocked; the content must be served over HTTPS.`